### PR TITLE
Add jest-circus `teardown` as a failsafe.

### DIFF
--- a/src/jest-environment-polly.js
+++ b/src/jest-environment-polly.js
@@ -89,8 +89,9 @@ export function PollyEnvironmentFactory(
       // Stop Polly instance if there is one running. We check `skip` in
       // addition to done because specs emit `test_start` even when they will be
       // then skipped
+      // Include `teardown` as a fail-safe.
       if (
-        ['test_done', 'test_skip'].includes(event.name) &&
+        ['teardown', 'test_done', 'test_skip'].includes(event.name) &&
         this.pollyGlobals.pollyContext.polly
       ) {
         await this.pollyGlobals.pollyContext.polly.stop();


### PR DESCRIPTION
Anecdotally, I've seen some weird interactions when running more than
one Polly-powered tests in a single runner (but maybe multi-threaded?).

This seemed to fix it, though I'm not 100% sure what the underlying
cause is. The docs on `jest-circus` events are pretty light, so it's not
clear to me when each of the events are called.

In either case, this still seems like a reasonable thing to have in
place, just as a fallback.